### PR TITLE
Valid JKube configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>Demo project for JKube resource fragment</description>
 	<properties>
 		<java.version>1.8</java.version>
+		<config-map.name>jkube-fragment-cm</config-map.name>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -48,7 +49,20 @@
 			<plugin>
 				<groupId>org.eclipse.jkube</groupId>
 				<artifactId>kubernetes-maven-plugin</artifactId>
-				<version>1.2.0</version>
+				<version>1.13.1</version>
+				<executions>
+					<execution>
+						<id>install</id>
+						<phase>install</phase>
+						<goals>
+							<goal>build</goal>
+							<!-- Should enable to push to a shared registry where image can be downloaded -->
+							<!--<goal>push</goal>-->
+							<goal>resource</goal>
+							<goal>apply</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-        		<groupId>org.eclipse.jkube</groupId>
-        		<artifactId>kubernetes-maven-plugin</artifactId>
-        		<version>1.2.0</version>
-      		</plugin>
+				<groupId>org.eclipse.jkube</groupId>
+				<artifactId>kubernetes-maven-plugin</artifactId>
+				<version>1.2.0</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/example/jkube/Demo.java
+++ b/src/main/java/com/example/jkube/Demo.java
@@ -6,14 +6,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class Demo {
-	
-	@Value("${welcome}")
-    private String welcome;
 
-    @GetMapping("/hello")
-    public String hello() {
-        return welcome;
-    }
-	
+	@Value("${welcome}")
+		private String welcome;
+
+		@GetMapping("/hello")
+		public String hello() {
+			return welcome;
+		}
+
 
 }

--- a/src/main/jkube/configmap.yml
+++ b/src/main/jkube/configmap.yml
@@ -1,5 +1,5 @@
 metadata:
-  name: ${project.artifactId}
+  name: ${config-map.name}
 data:
   application.properties: |
     # spring application properties file

--- a/src/main/jkube/deployment.yml
+++ b/src/main/jkube/deployment.yml
@@ -5,7 +5,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: ${project.artifactId}
+            name: ${config-map.name}
             items:
               - key: application.properties
                 path: application.properties

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+welcome=Hello From Test


### PR DESCRIPTION
## Description

Provided a valid JKube configuration to achieve everything that was reported in https://github.com/eclipse/jkube/issues/662

The `ConfigMap` name was wrong (not valid for Kubernetes API). In this fix I'm providing a specific name for the `ConfigMap`. The alternative would be to rename the `artifactId` and make it compliant with Kubernetes. JKube does handle this case when the `ConfigMap` name is not provided. However, since then you need to reference the artifactId in the Deployment fragment, JKube's name transformations are not available and `${project.artifactId}` returns a different name to that JKube decided to apply to the resources.

The JKube execution was configured to perform all valid steps during the Maven `install` phase. If running on Minikube, you'd simply need to run:
```shell
eval $(minikube docker-env)
mvn install
```
Everything will be taken care of. If running on a regular cluster, you need to uncomment the push goal and provide valid settings for your Docker/OCI registry.